### PR TITLE
Release/v1.1.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: Generate code coverage badge
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   test:

--- a/rules/after.go
+++ b/rules/after.go
@@ -79,3 +79,8 @@ func (r *After) AddParams(params []string) {
 func (*After) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the After rule does not require the field to exist.
+func (*After) RequiresField() bool {
+	return false
+}

--- a/rules/after_or_equal.go
+++ b/rules/after_or_equal.go
@@ -79,3 +79,8 @@ func (r *AfterOrEqual) AddParams(params []string) {
 func (*AfterOrEqual) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the AfterOrEqual rule does not require the field to exist.
+func (*AfterOrEqual) RequiresField() bool {
+	return false
+}

--- a/rules/after_or_equal_test.go
+++ b/rules/after_or_equal_test.go
@@ -171,3 +171,8 @@ func TestAfterOrEqual_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestAfterOrEqual_RequiresField(t *testing.T) {
+	rule := &AfterOrEqual{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/after_test.go
+++ b/rules/after_test.go
@@ -154,3 +154,8 @@ func TestAfter_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestAfter_RequiresField(t *testing.T) {
+	rule := &After{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/alpha.go
+++ b/rules/alpha.go
@@ -29,3 +29,8 @@ func (r *Alpha) Validate(selector string, value any, _ bag.InputBag) ValidationR
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Alpha rule does not require the field to exist.
+func (*Alpha) RequiresField() bool {
+	return false
+}

--- a/rules/alpha_dash.go
+++ b/rules/alpha_dash.go
@@ -29,3 +29,8 @@ func (r *AlphaDash) Validate(selector string, value any, _ bag.InputBag) Validat
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the AlphaDash rule does not require the field to exist.
+func (*AlphaDash) RequiresField() bool {
+	return false
+}

--- a/rules/alpha_dash_test.go
+++ b/rules/alpha_dash_test.go
@@ -78,3 +78,8 @@ func initAlphaDashRule() *AlphaDash {
 	})
 	return alphaRule
 }
+
+func TestAlphaDash_RequiresField(t *testing.T) {
+	rule := &AlphaDash{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/alpha_num.go
+++ b/rules/alpha_num.go
@@ -29,3 +29,8 @@ func (r *AlphaNum) Validate(selector string, value any, _ bag.InputBag) Validati
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the AlphaNum rule does not require the field to exist.
+func (*AlphaNum) RequiresField() bool {
+	return false
+}

--- a/rules/alpha_num_test.go
+++ b/rules/alpha_num_test.go
@@ -78,3 +78,8 @@ func initAlphaNumRule() *AlphaNum {
 	})
 	return alphaRule
 }
+
+func TestAlphaNum_RequiresField(t *testing.T) {
+	rule := &AlphaNum{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/alpha_space.go
+++ b/rules/alpha_space.go
@@ -29,3 +29,8 @@ func (r *AlphaSpace) Validate(selector string, value any, _ bag.InputBag) Valida
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the AlphaSpace rule does not require the field to exist.
+func (*AlphaSpace) RequiresField() bool {
+	return false
+}

--- a/rules/alpha_space_test.go
+++ b/rules/alpha_space_test.go
@@ -78,3 +78,8 @@ func initAlphaSpaceRule() *AlphaSpace {
 	})
 	return alphaRule
 }
+
+func TestAlphaSpace_RequiresField(t *testing.T) {
+	rule := &AlphaSpace{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/alpha_test.go
+++ b/rules/alpha_test.go
@@ -77,3 +77,8 @@ func initAlphaRule() *Alpha {
 	})
 	return alphaRule
 }
+
+func TestAlpha_RequiresField(t *testing.T) {
+	rule := &Alpha{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/array.go
+++ b/rules/array.go
@@ -26,3 +26,8 @@ func (r *Array) Validate(selector string, value any, _ bag.InputBag) ValidationR
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Array rule does not require the field to exist.
+func (*Array) RequiresField() bool {
+	return false
+}

--- a/rules/array_test.go
+++ b/rules/array_test.go
@@ -80,3 +80,8 @@ func initArrayRule() *Array {
 	})
 	return alphaRule
 }
+
+func TestArray_RequiresField(t *testing.T) {
+	rule := &Array{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/before.go
+++ b/rules/before.go
@@ -79,3 +79,8 @@ func (r *Before) AddParams(params []string) {
 func (*Before) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Before rule does not require the field to exist.
+func (*Before) RequiresField() bool {
+	return false
+}

--- a/rules/before_or_equal.go
+++ b/rules/before_or_equal.go
@@ -79,3 +79,8 @@ func (r *BeforeOrEqual) AddParams(params []string) {
 func (*BeforeOrEqual) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the BeforeOrEqual rule does not require the field to exist.
+func (*BeforeOrEqual) RequiresField() bool {
+	return false
+}

--- a/rules/before_or_equal_test.go
+++ b/rules/before_or_equal_test.go
@@ -171,3 +171,8 @@ func TestBeforeOrEqual_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestBeforeOrEqual_RequiresField(t *testing.T) {
+	rule := &BeforeOrEqual{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/before_test.go
+++ b/rules/before_test.go
@@ -154,3 +154,8 @@ func TestBefore_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestBefore_RequiresField(t *testing.T) {
+	rule := &Before{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/between.go
+++ b/rules/between.go
@@ -67,3 +67,8 @@ func (r *Between) AddParams(params []string) {
 func (*Between) MinRequiredParams() int {
 	return 2
 }
+
+// RequiresField returns false as the Between rule does not require the field to exist.
+func (*Between) RequiresField() bool {
+	return false
+}

--- a/rules/between_test.go
+++ b/rules/between_test.go
@@ -250,3 +250,8 @@ func TestBetween_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestBetween_RequiresField(t *testing.T) {
+	rule := &Between{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/boolean.go
+++ b/rules/boolean.go
@@ -27,3 +27,8 @@ func (r *Boolean) Validate(selector string, value any, _ bag.InputBag) Validatio
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Boolean rule does not require the field to exist.
+func (*Boolean) RequiresField() bool {
+	return false
+}

--- a/rules/boolean_test.go
+++ b/rules/boolean_test.go
@@ -124,3 +124,8 @@ func initBooleanRule() *Boolean {
 
 	return booleanRule
 }
+
+func TestBoolean_RequiresField(t *testing.T) {
+	rule := &Boolean{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/contracts.go
+++ b/rules/contracts.go
@@ -39,6 +39,7 @@ func (r ValidationResult) Failed() bool {
 // Rule is an interface for rules.
 type Rule interface {
 	Validate(selector string, value any, inputBag bag.InputBag) ValidationResult
+	RequiresField() bool
 }
 
 // RuleWithParams is an interface for rules that have parameters.

--- a/rules/datetime.go
+++ b/rules/datetime.go
@@ -27,3 +27,8 @@ func (r *DateTime) Validate(selector string, value any, _ bag.InputBag) Validati
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the DateTime rule does not require the field to exist.
+func (*DateTime) RequiresField() bool {
+	return false
+}

--- a/rules/datetime_after.go
+++ b/rules/datetime_after.go
@@ -62,3 +62,8 @@ func (r *DateTimeAfter) AddParams(params []string) {
 // It specifies how many parameters must be provided when configuring this rule.
 // Returns 1, indicating that the `value` parameter is mandatory, while the `timeZone` parameter is optional.
 func (*DateTimeAfter) MinRequiredParams() int { return 1 }
+
+// RequiresField returns false as the DateTimeAfter rule does not require the field to exist.
+func (*DateTimeAfter) RequiresField() bool {
+	return false
+}

--- a/rules/datetime_after_test.go
+++ b/rules/datetime_after_test.go
@@ -74,3 +74,8 @@ func initDateTimeAfterRule() *DateTimeAfter {
 	})
 	return r
 }
+
+func TestDateTimeAfter_RequiresField(t *testing.T) {
+	rule := &DateTimeAfter{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/datetime_before.go
+++ b/rules/datetime_before.go
@@ -61,3 +61,8 @@ func (r *DateTimeBefore) AddParams(params []string) {
 // It specifies how many parameters must be provided when configuring this rule.
 // Returns 1, indicating that the `value` parameter is mandatory, while the `timeZone` parameter is optional.
 func (*DateTimeBefore) MinRequiredParams() int { return 1 }
+
+// RequiresField returns false as the DateTimeBefore rule does not require the field to exist.
+func (*DateTimeBefore) RequiresField() bool {
+	return false
+}

--- a/rules/datetime_before_test.go
+++ b/rules/datetime_before_test.go
@@ -68,3 +68,8 @@ func initDateTimeBeforeRule() *DateTimeBefore {
 	})
 	return r
 }
+
+func TestDateTimeBefore_RequiresField(t *testing.T) {
+	rule := &DateTimeBefore{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/datetime_between.go
+++ b/rules/datetime_between.go
@@ -66,3 +66,8 @@ func (r *DateTimeBetween) AddParams(params []string) {
 // It specifies how many parameters must be provided when configuring this rule.
 // Returns 2, indicating that the `min` and `max` parameters are mandatory, while the `timeZone` parameter is optional.
 func (*DateTimeBetween) MinRequiredParams() int { return 2 }
+
+// RequiresField returns false as the DateTimeBetween rule does not require the field to exist.
+func (*DateTimeBetween) RequiresField() bool {
+	return false
+}

--- a/rules/datetime_between_test.go
+++ b/rules/datetime_between_test.go
@@ -68,3 +68,8 @@ func initDateTimeBetweenRule() *DateTimeBetween {
 	})
 	return r
 }
+
+func TestDateTimeBetween_RequiresField(t *testing.T) {
+	rule := &DateTimeBetween{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/datetime_format.go
+++ b/rules/datetime_format.go
@@ -48,3 +48,8 @@ func (r *DateTimeFormat) AddParams(params []string) {
 func (*DateTimeFormat) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the DateTimeFormat rule does not require the field to exist.
+func (*DateTimeFormat) RequiresField() bool {
+	return false
+}

--- a/rules/datetime_format_test.go
+++ b/rules/datetime_format_test.go
@@ -105,3 +105,8 @@ func TestDateTimeFormat_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestDateTimeFormat_RequiresField(t *testing.T) {
+	rule := &DateTimeFormat{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/datetime_test.go
+++ b/rules/datetime_test.go
@@ -78,3 +78,8 @@ func initDateTimeRule() *DateTime {
 
 	return datetimeRule
 }
+
+func TestDateTime_RequiresField(t *testing.T) {
+	rule := &DateTime{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/different.go
+++ b/rules/different.go
@@ -41,3 +41,8 @@ func (r *Different) AddParams(params []string) {
 func (*Different) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Different rule does not require the field to exist.
+func (*Different) RequiresField() bool {
+	return false
+}

--- a/rules/different_test.go
+++ b/rules/different_test.go
@@ -93,3 +93,8 @@ func TestDifferent_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestDifferent_RequiresField(t *testing.T) {
+	rule := &Different{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/digits.go
+++ b/rules/digits.go
@@ -44,3 +44,8 @@ func (r *Digits) AddParams(params []string) {
 func (*Digits) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Digits rule does not require the field to exist.
+func (*Digits) RequiresField() bool {
+	return false
+}

--- a/rules/digits_between.go
+++ b/rules/digits_between.go
@@ -47,3 +47,8 @@ func (r *DigitsBetween) AddParams(params []string) {
 func (*DigitsBetween) MinRequiredParams() int {
 	return 2
 }
+
+// RequiresField returns false as the DigitsBetween rule does not require the field to exist.
+func (*DigitsBetween) RequiresField() bool {
+	return false
+}

--- a/rules/digits_between_test.go
+++ b/rules/digits_between_test.go
@@ -91,3 +91,8 @@ func TestDigitsBetween_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestDigitsBetween_RequiresField(t *testing.T) {
+	rule := &DigitsBetween{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/digits_test.go
+++ b/rules/digits_test.go
@@ -106,3 +106,8 @@ func TestDigits_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestDigits_RequiresField(t *testing.T) {
+	rule := &Digits{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/distinct.go
+++ b/rules/distinct.go
@@ -49,3 +49,8 @@ func (r *Distinct) Validate(selector string, value any, _ bag.InputBag) Validati
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Distinct rule does not require the field to exist.
+func (*Distinct) RequiresField() bool {
+	return false
+}

--- a/rules/distinct_test.go
+++ b/rules/distinct_test.go
@@ -173,3 +173,8 @@ func initDistinctRule() *Distinct {
 	})
 	return r
 }
+
+func TestDistinct_RequiresField(t *testing.T) {
+	rule := &Distinct{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/email.go
+++ b/rules/email.go
@@ -92,3 +92,8 @@ func (r *Email) checkMXRecord() bool {
 
 	return true
 }
+
+// RequiresField returns false as the Email rule does not require the field to exist.
+func (*Email) RequiresField() bool {
+	return false
+}

--- a/rules/email_test.go
+++ b/rules/email_test.go
@@ -152,3 +152,8 @@ func TestEmail_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 0, rule.MinRequiredParams())
 }
+
+func TestEmail_RequiresField(t *testing.T) {
+	rule := &Email{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/ends_with.go
+++ b/rules/ends_with.go
@@ -43,3 +43,8 @@ func (r *EndsWith) AddParams(params []string) {
 func (*EndsWith) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the EndsWith rule does not require the field to exist.
+func (*EndsWith) RequiresField() bool {
+	return false
+}

--- a/rules/ends_with_test.go
+++ b/rules/ends_with_test.go
@@ -109,3 +109,8 @@ func TestEndsWith_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestEndsWith_RequiresField(t *testing.T) {
+	rule := &EndsWith{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/gt.go
+++ b/rules/gt.go
@@ -61,3 +61,8 @@ func (r *GreaterThan) AddParams(params []string) {
 func (*GreaterThan) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the GreaterThan rule does not require the field to exist.
+func (*GreaterThan) RequiresField() bool {
+	return false
+}

--- a/rules/gt_test.go
+++ b/rules/gt_test.go
@@ -245,3 +245,8 @@ func TestGreaterThan_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestGreaterThan_RequiresField(t *testing.T) {
+	rule := &GreaterThan{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/gte.go
+++ b/rules/gte.go
@@ -61,3 +61,8 @@ func (r *GreaterThanEqual) AddParams(params []string) {
 func (*GreaterThanEqual) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the GreaterThanEqual rule does not require the field to exist.
+func (*GreaterThanEqual) RequiresField() bool {
+	return false
+}

--- a/rules/gte_test.go
+++ b/rules/gte_test.go
@@ -244,3 +244,8 @@ func TestGreaterThanEqual_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestGreaterThanEqual_RequiresField(t *testing.T) {
+	rule := &GreaterThanEqual{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/in.go
+++ b/rules/in.go
@@ -48,3 +48,8 @@ func (r *In) AddParams(params []string) {
 func (*In) MinRequiredParams() int {
 	return 2
 }
+
+// RequiresField returns false as the In rule does not require the field to exist.
+func (*In) RequiresField() bool {
+	return false
+}

--- a/rules/in_array_field.go
+++ b/rules/in_array_field.go
@@ -56,6 +56,11 @@ func (r *InArrayField) AddParams(params []string) {
 // Returns 1, indicating that the `otherField` parameter is mandatory.
 func (*InArrayField) MinRequiredParams() int { return 1 }
 
+// RequiresField returns false as the InArrayField rule does not require the field to exist.
+func (*InArrayField) RequiresField() bool {
+	return false
+}
+
 func toComparableString(v any) string {
 	s, ok := v.(string)
 	if ok {

--- a/rules/in_array_field_test.go
+++ b/rules/in_array_field_test.go
@@ -89,3 +89,8 @@ func initInArrayFieldRule() *InArrayField {
 	})
 	return r
 }
+
+func TestInArrayField_RequiresField(t *testing.T) {
+	rule := &InArrayField{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/in_test.go
+++ b/rules/in_test.go
@@ -91,3 +91,8 @@ func TestIn_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestIn_RequiresField(t *testing.T) {
+	rule := &In{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/integer.go
+++ b/rules/integer.go
@@ -33,3 +33,8 @@ func (r *Integer) Validate(selector string, value any, _ bag.InputBag) Validatio
 		}))
 	}
 }
+
+// RequiresField returns false as the Integer rule does not require the field to exist.
+func (*Integer) RequiresField() bool {
+	return false
+}

--- a/rules/integer_test.go
+++ b/rules/integer_test.go
@@ -138,3 +138,8 @@ func initIntegerRule() *Integer {
 	})
 	return integerRule
 }
+
+func TestInteger_RequiresField(t *testing.T) {
+	rule := &Integer{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/ip.go
+++ b/rules/ip.go
@@ -28,3 +28,8 @@ func (r *IP) Validate(selector string, value any, _ bag.InputBag) ValidationResu
 	}
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the IP rule does not require the field to exist.
+func (*IP) RequiresField() bool {
+	return false
+}

--- a/rules/ip_test.go
+++ b/rules/ip_test.go
@@ -99,3 +99,8 @@ func initIPRule() *IP {
 	})
 	return r
 }
+
+func TestIP_RequiresField(t *testing.T) {
+	rule := &IP{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/ipv4.go
+++ b/rules/ipv4.go
@@ -29,3 +29,8 @@ func (r *IPv4) Validate(selector string, value any, _ bag.InputBag) ValidationRe
 	}
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the IPv4 rule does not require the field to exist.
+func (*IPv4) RequiresField() bool {
+	return false
+}

--- a/rules/ipv4_test.go
+++ b/rules/ipv4_test.go
@@ -57,3 +57,8 @@ func initIPv4Rule() *IPv4 {
 	})
 	return r
 }
+
+func TestIPv4_RequiresField(t *testing.T) {
+	rule := &IPv4{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/ipv6.go
+++ b/rules/ipv6.go
@@ -29,3 +29,8 @@ func (r *IPv6) Validate(selector string, value any, _ bag.InputBag) ValidationRe
 	}
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the IPv6 rule does not require the field to exist.
+func (*IPv6) RequiresField() bool {
+	return false
+}

--- a/rules/ipv6_test.go
+++ b/rules/ipv6_test.go
@@ -57,3 +57,8 @@ func initIPv6Rule() *IPv6 {
 	})
 	return r
 }
+
+func TestIPv6_RequiresField(t *testing.T) {
+	rule := &IPv6{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/length.go
+++ b/rules/length.go
@@ -57,3 +57,8 @@ func (r *Length) AddParams(params []string) {
 func (*Length) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Length rule does not require the field to exist.
+func (*Length) RequiresField() bool {
+	return false
+}

--- a/rules/length_test.go
+++ b/rules/length_test.go
@@ -187,3 +187,8 @@ func TestLength_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestLength_RequiresField(t *testing.T) {
+	rule := &Length{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/lowercase.go
+++ b/rules/lowercase.go
@@ -30,3 +30,8 @@ func (r *Lowercase) Validate(selector string, value any, _ bag.InputBag) Validat
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Lowercase rule does not require the field to exist.
+func (*Lowercase) RequiresField() bool {
+	return false
+}

--- a/rules/lowercase_test.go
+++ b/rules/lowercase_test.go
@@ -77,3 +77,8 @@ func initLowercaseRule() *Lowercase {
 	})
 	return lowercaseRule
 }
+
+func TestLowercase_RequiresField(t *testing.T) {
+	rule := &Lowercase{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/lt.go
+++ b/rules/lt.go
@@ -61,3 +61,8 @@ func (r *LessThan) AddParams(params []string) {
 func (*LessThan) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the LessThan rule does not require the field to exist.
+func (*LessThan) RequiresField() bool {
+	return false
+}

--- a/rules/lt_test.go
+++ b/rules/lt_test.go
@@ -247,3 +247,8 @@ func TestLessThan_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestLessThan_RequiresField(t *testing.T) {
+	rule := &LessThan{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/lte.go
+++ b/rules/lte.go
@@ -61,3 +61,8 @@ func (r *LessThanEqual) AddParams(params []string) {
 func (*LessThanEqual) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the LessThanEqual rule does not require the field to exist.
+func (*LessThanEqual) RequiresField() bool {
+	return false
+}

--- a/rules/lte_test.go
+++ b/rules/lte_test.go
@@ -247,3 +247,8 @@ func TestLessThanEqual_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestLessThanEqual_RequiresField(t *testing.T) {
+	rule := &LessThanEqual{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/mac_address.go
+++ b/rules/mac_address.go
@@ -31,3 +31,8 @@ func (r *MacAddress) Validate(selector string, value any, _ bag.InputBag) Valida
 	}
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the MacAddress rule does not require the field to exist.
+func (*MacAddress) RequiresField() bool {
+	return false
+}

--- a/rules/mac_address_test.go
+++ b/rules/mac_address_test.go
@@ -61,3 +61,8 @@ func initMacRule() *MacAddress {
 	})
 	return r
 }
+
+func TestMacAddress_RequiresField(t *testing.T) {
+	rule := &MacAddress{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/max.go
+++ b/rules/max.go
@@ -41,3 +41,8 @@ func (r *Max) AddParams(params []string) {
 func (*Max) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Max rule does not require the field to exist.
+func (*Max) RequiresField() bool {
+	return false
+}

--- a/rules/max_digits.go
+++ b/rules/max_digits.go
@@ -46,3 +46,8 @@ func (r *MaxDigits) AddParams(params []string) {
 func (*MaxDigits) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the MaxDigits rule does not require the field to exist.
+func (*MaxDigits) RequiresField() bool {
+	return false
+}

--- a/rules/max_digits_test.go
+++ b/rules/max_digits_test.go
@@ -91,3 +91,8 @@ func TestMaxDigits_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestMaxDigits_RequiresField(t *testing.T) {
+	rule := &MaxDigits{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/max_length.go
+++ b/rules/max_length.go
@@ -57,3 +57,8 @@ func (r *MaxLength) AddParams(params []string) {
 func (*MaxLength) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the MaxLength rule does not require the field to exist.
+func (*MaxLength) RequiresField() bool {
+	return false
+}

--- a/rules/max_length_test.go
+++ b/rules/max_length_test.go
@@ -187,3 +187,8 @@ func TestMaxLength_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestMaxLength_RequiresField(t *testing.T) {
+	rule := &MaxLength{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/max_test.go
+++ b/rules/max_test.go
@@ -121,3 +121,8 @@ func TestMax_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestMax_RequiresField(t *testing.T) {
+	rule := &Max{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/min.go
+++ b/rules/min.go
@@ -43,3 +43,8 @@ func (r *Min) AddParams(params []string) {
 func (*Min) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Min rule does not require the field to exist.
+func (*Min) RequiresField() bool {
+	return false
+}

--- a/rules/min_digits.go
+++ b/rules/min_digits.go
@@ -46,3 +46,8 @@ func (r *MinDigits) AddParams(params []string) {
 func (*MinDigits) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the MinDigits rule does not require the field to exist.
+func (*MinDigits) RequiresField() bool {
+	return false
+}

--- a/rules/min_digits_test.go
+++ b/rules/min_digits_test.go
@@ -91,3 +91,8 @@ func TestMinDigits_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestMinDigits_RequiresField(t *testing.T) {
+	rule := &MinDigits{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/min_length.go
+++ b/rules/min_length.go
@@ -57,3 +57,8 @@ func (r *MinLength) AddParams(params []string) {
 func (*MinLength) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the MinLength rule does not require the field to exist.
+func (*MinLength) RequiresField() bool {
+	return false
+}

--- a/rules/min_length_test.go
+++ b/rules/min_length_test.go
@@ -187,3 +187,8 @@ func TestMinLength_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestMinLength_RequiresField(t *testing.T) {
+	rule := &MinLength{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/min_test.go
+++ b/rules/min_test.go
@@ -121,3 +121,8 @@ func TestMin_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestMin_RequiresField(t *testing.T) {
+	rule := &Min{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/neq.go
+++ b/rules/neq.go
@@ -41,3 +41,8 @@ func (r *NotEqual) AddParams(params []string) {
 func (*NotEqual) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the NotEqual rule does not require the field to exist.
+func (*NotEqual) RequiresField() bool {
+	return false
+}

--- a/rules/neq_test.go
+++ b/rules/neq_test.go
@@ -91,3 +91,8 @@ func TestNotEqual_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestNotEqual_RequiresField(t *testing.T) {
+	rule := &NotEqual{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/not_empty.go
+++ b/rules/not_empty.go
@@ -26,3 +26,8 @@ func (r *NotEmpty) Validate(selector string, value any, _ bag.InputBag) Validati
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns true as the NotEmpty rule requires the field to exist.
+func (*NotEmpty) RequiresField() bool {
+	return true
+}

--- a/rules/not_empty_test.go
+++ b/rules/not_empty_test.go
@@ -113,3 +113,8 @@ func initNotEmptyRule() *NotEmpty {
 	})
 	return notEmptyRule
 }
+
+func TestNotEmpty_RequiresField(t *testing.T) {
+	rule := &NotEmpty{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/not_in.go
+++ b/rules/not_in.go
@@ -45,3 +45,8 @@ func (r *NotIn) AddParams(params []string) {
 func (*NotIn) MinRequiredParams() int {
 	return 2
 }
+
+// RequiresField returns false as the NotIn rule does not require the field to exist.
+func (*NotIn) RequiresField() bool {
+	return false
+}

--- a/rules/not_in_test.go
+++ b/rules/not_in_test.go
@@ -91,3 +91,8 @@ func TestNotIn_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestNotIn_RequiresField(t *testing.T) {
+	rule := &NotIn{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/not_regex.go
+++ b/rules/not_regex.go
@@ -44,3 +44,8 @@ func (r *NotRegex) AddParams(params []string) {
 func (*NotRegex) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the NotRegex rule does not require the field to exist.
+func (*NotRegex) RequiresField() bool {
+	return false
+}

--- a/rules/not_regex_test.go
+++ b/rules/not_regex_test.go
@@ -115,3 +115,8 @@ func TestNotRegex_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestNotRegex_RequiresField(t *testing.T) {
+	rule := &NotRegex{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/numeric.go
+++ b/rules/numeric.go
@@ -27,3 +27,8 @@ func (r *Numeric) Validate(selector string, value any, _ bag.InputBag) Validatio
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Numeric rule does not require the field to exist.
+func (*Numeric) RequiresField() bool {
+	return false
+}

--- a/rules/numeric_test.go
+++ b/rules/numeric_test.go
@@ -128,3 +128,8 @@ func initNumericRule() *Numeric {
 	})
 	return numericRule
 }
+
+func TestNumeric_RequiresField(t *testing.T) {
+	rule := &Numeric{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/regex.go
+++ b/rules/regex.go
@@ -44,3 +44,8 @@ func (r *Regex) AddParams(params []string) {
 func (*Regex) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the Regex rule does not require the field to exist.
+func (*Regex) RequiresField() bool {
+	return false
+}

--- a/rules/regex_test.go
+++ b/rules/regex_test.go
@@ -108,3 +108,8 @@ func TestRegex_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestRegex_RequiresField(t *testing.T) {
+	rule := &Regex{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/required.go
+++ b/rules/required.go
@@ -24,3 +24,8 @@ func (r *Required) Validate(selector string, _ any, inputBag bag.InputBag) Valid
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns true as the Required rule requires the field to exist.
+func (*Required) RequiresField() bool {
+	return true
+}

--- a/rules/required_if.go
+++ b/rules/required_if.go
@@ -50,3 +50,8 @@ func (r *RequiredIf) AddParams(params []string) {
 func (*RequiredIf) MinRequiredParams() int {
 	return 2
 }
+
+// RequiresField returns true as the RequiredIf rule requires the field to exist.
+func (*RequiredIf) RequiresField() bool {
+	return true
+}

--- a/rules/required_if_test.go
+++ b/rules/required_if_test.go
@@ -107,3 +107,8 @@ func TestRequiredIf_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestRequiredIf_RequiresField(t *testing.T) {
+	rule := &RequiredIf{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/required_test.go
+++ b/rules/required_test.go
@@ -78,3 +78,8 @@ func initRequiredRule() *Required {
 	})
 	return requiredRule
 }
+
+func TestRequired_RequiresField(t *testing.T) {
+	rule := &Required{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/required_unless.go
+++ b/rules/required_unless.go
@@ -50,3 +50,8 @@ func (r *RequiredUnless) AddParams(params []string) {
 func (*RequiredUnless) MinRequiredParams() int {
 	return 2
 }
+
+// RequiresField returns true as the RequiredUnless rule requires the field to exist.
+func (*RequiredUnless) RequiresField() bool {
+	return true
+}

--- a/rules/required_unless_test.go
+++ b/rules/required_unless_test.go
@@ -99,3 +99,8 @@ func TestRequiredUnless_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestRequiredUnless_RequiresField(t *testing.T) {
+	rule := &RequiredUnless{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/required_with.go
+++ b/rules/required_with.go
@@ -47,3 +47,8 @@ func (r *RequiredWith) AddParams(params []string) {
 func (*RequiredWith) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns true as the RequiredWith rule requires the field to exist.
+func (*RequiredWith) RequiresField() bool {
+	return true
+}

--- a/rules/required_with_all.go
+++ b/rules/required_with_all.go
@@ -61,3 +61,8 @@ func (r *RequiredWithAll) getOtherFieldsConcatenated() string {
 	i := strings.LastIndex(output, ",")
 	return output[:i+1] + " and" + output[i+1:]
 }
+
+// RequiresField returns true as the RequiredWithAll rule requires the field to exist.
+func (*RequiredWithAll) RequiresField() bool {
+	return true
+}

--- a/rules/required_with_all_test.go
+++ b/rules/required_with_all_test.go
@@ -126,3 +126,8 @@ func TestRequiredWithAll_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestRequiredWithAll_RequiresField(t *testing.T) {
+	rule := &RequiredWithAll{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/required_with_test.go
+++ b/rules/required_with_test.go
@@ -122,3 +122,8 @@ func TestRequiredWith_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestRequiredWith_RequiresField(t *testing.T) {
+	rule := &RequiredWith{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/required_without.go
+++ b/rules/required_without.go
@@ -47,3 +47,8 @@ func (r *RequiredWithout) AddParams(params []string) {
 func (*RequiredWithout) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns true as the RequiredWithout rule requires the field to exist.
+func (*RequiredWithout) RequiresField() bool {
+	return true
+}

--- a/rules/required_without_all.go
+++ b/rules/required_without_all.go
@@ -61,3 +61,8 @@ func (r *RequiredWithoutAll) getOtherFieldsConcatenated() string {
 	i := strings.LastIndex(output, ",")
 	return output[:i+1] + " and" + output[i+1:]
 }
+
+// RequiresField returns true as the RequiredWithoutAll rule requires the field to exist.
+func (*RequiredWithoutAll) RequiresField() bool {
+	return true
+}

--- a/rules/required_without_all_test.go
+++ b/rules/required_without_all_test.go
@@ -117,3 +117,8 @@ func TestRequiredWithoutAll_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 2, rule.MinRequiredParams())
 }
+
+func TestRequiredWithoutAll_RequiresField(t *testing.T) {
+	rule := &RequiredWithoutAll{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/required_without_test.go
+++ b/rules/required_without_test.go
@@ -105,3 +105,8 @@ func TestRequiredWithout_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestRequiredWithout_RequiresField(t *testing.T) {
+	rule := &RequiredWithout{}
+	assert.True(t, rule.RequiresField())
+}

--- a/rules/same_as.go
+++ b/rules/same_as.go
@@ -41,3 +41,8 @@ func (r *SameAs) AddParams(params []string) {
 func (*SameAs) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the SameAs rule does not require the field to exist.
+func (*SameAs) RequiresField() bool {
+	return false
+}

--- a/rules/same_as_test.go
+++ b/rules/same_as_test.go
@@ -109,3 +109,8 @@ func TestSameAs_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestSameAs_RequiresField(t *testing.T) {
+	rule := &SameAs{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/starts_with.go
+++ b/rules/starts_with.go
@@ -43,3 +43,8 @@ func (r *StartsWith) AddParams(params []string) {
 func (*StartsWith) MinRequiredParams() int {
 	return 1
 }
+
+// RequiresField returns false as the StartsWith rule does not require the field to exist.
+func (*StartsWith) RequiresField() bool {
+	return false
+}

--- a/rules/starts_with_test.go
+++ b/rules/starts_with_test.go
@@ -109,3 +109,8 @@ func TestStartsWith_MinRequiredParams(t *testing.T) {
 
 	assert.Equal(t, 1, rule.MinRequiredParams())
 }
+
+func TestStartsWith_RequiresField(t *testing.T) {
+	rule := &StartsWith{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/string.go
+++ b/rules/string.go
@@ -32,3 +32,8 @@ func (r *String) Validate(selector string, value any, _ bag.InputBag) Validation
 		}))
 	}
 }
+
+// RequiresField returns false as the String rule does not require the field to exist.
+func (*String) RequiresField() bool {
+	return false
+}

--- a/rules/string_test.go
+++ b/rules/string_test.go
@@ -138,3 +138,8 @@ func initStringRule() *String {
 	})
 	return stringRule
 }
+
+func TestString_RequiresField(t *testing.T) {
+	rule := &String{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/timezone.go
+++ b/rules/timezone.go
@@ -33,3 +33,8 @@ func (r *Timezone) Validate(selector string, value any, _ bag.InputBag) Validati
 	}
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Timezone rule does not require the field to exist.
+func (*Timezone) RequiresField() bool {
+	return false
+}

--- a/rules/timezone_test.go
+++ b/rules/timezone_test.go
@@ -61,3 +61,8 @@ func initTimezoneRule() *Timezone {
 	})
 	return r
 }
+
+func TestTimezone_RequiresField(t *testing.T) {
+	rule := &Timezone{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/uppercase.go
+++ b/rules/uppercase.go
@@ -30,3 +30,8 @@ func (r *Uppercase) Validate(selector string, value any, _ bag.InputBag) Validat
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the Uppercase rule does not require the field to exist.
+func (*Uppercase) RequiresField() bool {
+	return false
+}

--- a/rules/uppercase_test.go
+++ b/rules/uppercase_test.go
@@ -77,3 +77,8 @@ func initUppercaseRule() *Uppercase {
 	})
 	return uppercaseRule
 }
+
+func TestUppercase_RequiresField(t *testing.T) {
+	rule := &Uppercase{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/url.go
+++ b/rules/url.go
@@ -32,18 +32,26 @@ func (r *URL) Validate(selector string, value any, _ bag.InputBag) ValidationRes
 	u, err := url.ParseRequestURI(raw)
 	if r.requireScheme {
 		if err != nil || u.Scheme == "" || !isValidURLHost(u.Host) {
-			return NewFailedResult(r.Translate(r.Locale, "validation.url", map[string]string{
-				"field": selector,
-			}))
+			return NewFailedResult(
+				r.Translate(
+					r.Locale, "validation.url", map[string]string{
+						"field": selector,
+					},
+				),
+			)
 		}
 	} else {
 		// Accept URLs without scheme by attempting to parse with an implied scheme
 		if err != nil || !isValidURLHost(u.Host) {
 			u2, err2 := url.Parse("http://" + raw)
 			if err2 != nil || !isValidURLHost(u2.Host) {
-				return NewFailedResult(r.Translate(r.Locale, "validation.url", map[string]string{
-					"field": selector,
-				}))
+				return NewFailedResult(
+					r.Translate(
+						r.Locale, "validation.url", map[string]string{
+							"field": selector,
+						},
+					),
+				)
 			}
 		}
 	}
@@ -73,7 +81,7 @@ func (*URL) MinRequiredParams() int { return 0 }
 // It accepts:
 // - domain-like hosts with at least one dot (e.g. "example.com")
 // - "localhost"
-// - valid IP addresses (IPv4 / IPv6, with or without port)
+// - valid IP addresses (IPv4 / IPv6, with or without port).
 func isValidURLHost(host string) bool {
 	if host == "" {
 		return false

--- a/rules/url.go
+++ b/rules/url.go
@@ -113,3 +113,8 @@ func isValidURLHost(host string) bool {
 
 	return true
 }
+
+// RequiresField returns false as the URL rule does not require the field to exist.
+func (*URL) RequiresField() bool {
+	return false
+}

--- a/rules/url_test.go
+++ b/rules/url_test.go
@@ -151,3 +151,8 @@ func initURLRule() *URL {
 	)
 	return urlRule
 }
+
+func TestURL_RequiresField(t *testing.T) {
+	rule := &URL{}
+	assert.False(t, rule.RequiresField())
+}

--- a/rules/uuid.go
+++ b/rules/uuid.go
@@ -33,3 +33,8 @@ func (r *UUID) Validate(selector string, value any, _ bag.InputBag) ValidationRe
 
 	return NewSuccessResult()
 }
+
+// RequiresField returns false as the UUID rule does not require the field to exist.
+func (*UUID) RequiresField() bool {
+	return false
+}

--- a/rules/uuid_test.go
+++ b/rules/uuid_test.go
@@ -77,3 +77,8 @@ func initUUIDRule() *UUID {
 	})
 	return uuidRule
 }
+
+func TestUUID_RequiresField(t *testing.T) {
+	rule := &UUID{}
+	assert.False(t, rule.RequiresField())
+}

--- a/validation.go
+++ b/validation.go
@@ -110,10 +110,15 @@ func doValidation(inputBag bag.InputBag, rulesMap RulesMap, locale string) Resul
 
 	result := NewResult()
 	for selector, selectorRules := range explicitRules {
-		val, _ := inputBag.Get(selector)
+		val, exists := inputBag.Get(selector)
 		for _, ruleStr := range selectorRules {
 			ruleName := ruleIndicator(ruleStr)
 			rule := ruleName.load(locale)
+
+			if !exists && !rule.RequiresField() {
+				continue
+			}
+
 			ruleResult := rule.Validate(selector, val, inputBag)
 			if ruleResult.Failed() {
 				result.addError(selector, ruleResult.Message())


### PR DESCRIPTION
Validation Rules now will be skipped if the selector couldn't be found on InputBag. The required family rules are specifically for validating the field exists.